### PR TITLE
Edit invalid command error message

### DIFF
--- a/src/main/java/seedu/address/logic/commands/contactcommands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contactcommands/DeleteCommand.java
@@ -21,7 +21,7 @@ public class DeleteCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the person identified by the index number used in the displayed person list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Parameters: INDEX (must be a positive integer from 0 to " + Integer.MAX_VALUE + ")\n"
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";

--- a/src/main/java/seedu/address/logic/commands/contactcommands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contactcommands/EditCommand.java
@@ -42,7 +42,7 @@ public class EditCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
             + "by the index number used in the displayed person list. "
             + "Existing values will be overwritten by the input values.\n"
-            + "Parameters: INDEX (must be a positive integer) "
+            + "Parameters: INDEX (must be a positive integer from 0 to " + Integer.MAX_VALUE + ") "
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "

--- a/src/main/java/seedu/address/logic/commands/tagcommands/LinkDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tagcommands/LinkDeleteCommand.java
@@ -22,7 +22,7 @@ public class LinkDeleteCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the link from the tag identified by the index number used in the displayed tag list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Parameters: INDEX (must be a positive integer from 0 to " + Integer.MAX_VALUE + ")\n"
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_DELETE_LINK_SUCCESS = "Deleted Link: %1$s from %2$s";

--- a/src/main/java/seedu/address/logic/commands/tagcommands/TagDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tagcommands/TagDeleteCommand.java
@@ -26,7 +26,7 @@ public class TagDeleteCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the tag identified by the index number used in the displayed tag list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Parameters: INDEX (must be a positive integer from 0 to " + Integer.MAX_VALUE + ")\n"
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_DELETE_TAG_SUCCESS = "Deleted Tag: %1$s";

--- a/src/main/java/seedu/address/logic/commands/tagcommands/TagEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tagcommands/TagEditCommand.java
@@ -27,7 +27,7 @@ public class TagEditCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the name of the tag identified "
             + "by the index number used in the displayed tag list. "
             + "Existing values will be overwritten by the input values.\n"
-            + "Parameters: INDEX (must be a positive integer) "
+            + "Parameters: INDEX (must be a positive integer from 0 to " + Integer.MAX_VALUE + ") "
             + PREFIX_TAG + "TAG NAME\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_TAG + "CS2101";

--- a/src/main/java/seedu/address/logic/commands/tagcommands/TaskAddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tagcommands/TaskAddCommand.java
@@ -27,7 +27,7 @@ public class TaskAddCommand extends Command {
     public static final String COMMAND_WORD = "taskadd";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a task to a tag. "
-            + "Parameters: INDEX (must be a positive integer) "
+            + "Parameters: INDEX (must be a positive integer from 0 to " + Integer.MAX_VALUE + ") "
             + PREFIX_TASK + "TASK DESCRIPTION "
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_TASK + "Peer review ";

--- a/src/main/java/seedu/address/logic/commands/tagcommands/TaskDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tagcommands/TaskDeleteCommand.java
@@ -24,7 +24,7 @@ public class TaskDeleteCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Delete the task identified by the alphabetical "
             + "index number used in the task list of the tag, which is identified by the numerical index used in "
             + "the displayed tag list. "
-            + "Parameters: INDEX (must be a positive integer) "
+            + "Parameters: INDEX (must be a positive integer from 0 to " + Integer.MAX_VALUE + ") "
             + "ALPHABETICAL INDEX (must be in lower case from 'a' to 'z')"
             + "Example: " + COMMAND_WORD + " 1 a";
 

--- a/src/main/java/seedu/address/logic/commands/tagcommands/TaskDoneCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tagcommands/TaskDoneCommand.java
@@ -23,7 +23,7 @@ public class TaskDoneCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Mark the task identified by the alphabetical "
             + "index number used in the task list of the tag, which is identified by the numerical index used in "
             + "the displayed tag list. "
-            + "Parameters: INDEX (must be a positive integer) "
+            + "Parameters: INDEX (must be a positive integer from 0 to " + Integer.MAX_VALUE + ") "
             + "ALPHABETICAL INDEX (must be in lower case from 'a' to 'z')"
             + "Example: " + COMMAND_WORD + " 1 a";
 

--- a/src/main/java/seedu/address/logic/parser/tagparsers/TagEditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/tagparsers/TagEditCommandParser.java
@@ -25,8 +25,7 @@ public class TagEditCommandParser implements Parser<TagEditCommand> {
      */
     public TagEditCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_TAG);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_TAG);
 
         Index index;
 


### PR DESCRIPTION
Numbers larger than Integer.MAX_VALUE are no longer counted as integers in Java, so large numbers as indexes should be a constraint rather than an invalid index. 

Error messages in all commands using index have been edited to reflect the new constraints.