### PR TITLE
Test Add, Edit, Find, Delete commands (Fix DeleteCommand)

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -270,7 +270,7 @@ Use our `find` command to look for that contact using words that his/her name co
   
 #### Sort contacts by name: `sort`
 
-Dislike how the current list of contacts is displayed? Sort the names in ascending number then alphabetical order by 
+Dislike how the current list of contacts is displayed? Sort the names in alphanumerical order by 
 typing a single `sort` word on the command line.
 
 <div markdown="span" class="alert alert-primary">:bulb: <b>Tip:</b>
@@ -415,7 +415,7 @@ Examples:
 #### Sorting tags by tag name: `tagsort`
 
 Dislike how the current list of tags is displayed? 
-Sort the tags by their names in ascending number then in alphabetical order by typing a single `tagsort` word on the command line.
+Sort the tags by their names in alphanumerical order by typing a single `tagsort` word on the command line.
 
 <div markdown="span" class="alert alert-primary">:bulb: <b>Tip:</b>
 Do you wish to get back to the previous tag list? No worries, this sorted tag list is not permanent! Simply enter `taglist` on the command line to get back to the chronological order.

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -7,10 +7,10 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid.";
+    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The contact index provided is invalid.";
     public static final String MESSAGE_INVALID_TAG_DISPLAYED_INDEX = "The tag index provided is invalid.";
     public static final String MESSAGE_INVALID_TASK_DISPLAYED_INDEX = "The task index provided is invalid.";
-    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
-    public static final String MESSAGE_TAGS_LISTED_OVERVIEW = "%1$d tags listed!";
+    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d contact(s) listed!";
+    public static final String MESSAGE_TAGS_LISTED_OVERVIEW = "%1$d tag(s) listed!";
     public static final String MESSAGE_NO_TASK_LIST = "There are no tasks under this tag!";
 }

--- a/src/main/java/seedu/address/logic/commands/contactcommands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contactcommands/AddCommand.java
@@ -26,7 +26,7 @@ public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the Projact. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the contact list. "
             + "Parameters: "
             + PREFIX_NAME + "NAME "
             + PREFIX_PHONE + "PHONE "

--- a/src/main/java/seedu/address/logic/commands/contactcommands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contactcommands/AddCommand.java
@@ -38,8 +38,8 @@ public class AddCommand extends Command {
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "
             + PREFIX_TELEGRAM_ADDRESS + "john_doe123 "
-            + PREFIX_TAG + "friends "
-            + PREFIX_TAG + "owesMoney";
+            + PREFIX_TAG + "cs2101 "
+            + PREFIX_TAG + "cs2103";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the Projact";

--- a/src/main/java/seedu/address/logic/commands/contactcommands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contactcommands/AddCommand.java
@@ -42,7 +42,8 @@ public class AddCommand extends Command {
             + PREFIX_TAG + "cs2103";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the Projact";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the contact list. "
+            + "Make sure the new contact is of a different name";
 
     private final Person toAdd;
 

--- a/src/main/java/seedu/address/logic/commands/contactcommands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contactcommands/DeleteCommand.java
@@ -21,7 +21,7 @@ public class DeleteCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the person identified by the index number used in the displayed person list.\n"
-            + "Parameters: INDEX (must be a positive integer from 0 to " + Integer.MAX_VALUE + ")\n"
+            + "Parameters: INDEX (must be a positive integer from 1 to " + Integer.MAX_VALUE + ")\n"
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";

--- a/src/main/java/seedu/address/logic/commands/contactcommands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contactcommands/DeleteCommand.java
@@ -43,6 +43,7 @@ public class DeleteCommand extends Command {
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deletePerson(personToDelete);
+        model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
     }
 

--- a/src/main/java/seedu/address/logic/commands/contactcommands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contactcommands/EditCommand.java
@@ -42,7 +42,7 @@ public class EditCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
             + "by the index number used in the displayed person list. "
             + "Existing values will be overwritten by the input values.\n"
-            + "Parameters: INDEX (must be a positive integer from 0 to " + Integer.MAX_VALUE + ") "
+            + "Parameters: INDEX (must be a positive integer from 1 to " + Integer.MAX_VALUE + ") "
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "

--- a/src/main/java/seedu/address/logic/commands/contactcommands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contactcommands/EditCommand.java
@@ -54,7 +54,8 @@ public class EditCommand extends Command {
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the Projact.";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the contact list."
+            + "Make sure the new contact is of a different name";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;

--- a/src/main/java/seedu/address/logic/commands/contactcommands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contactcommands/SortCommand.java
@@ -15,7 +15,7 @@ public class SortCommand extends Command {
     public static final String COMMAND_WORD = "sort";
 
     public static final String MESSAGE_SUCCESS = "These are the contacts in your person list "
-                                                    + "sorted in ascending number then alphabetical order.";
+                                                    + "sorted in alphanumerical order.";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/address/logic/commands/tagcommands/LinkDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tagcommands/LinkDeleteCommand.java
@@ -22,7 +22,7 @@ public class LinkDeleteCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the link from the tag identified by the index number used in the displayed tag list.\n"
-            + "Parameters: INDEX (must be a positive integer from 0 to " + Integer.MAX_VALUE + ")\n"
+            + "Parameters: INDEX (must be a positive integer from 1 to " + Integer.MAX_VALUE + ")\n"
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_DELETE_LINK_SUCCESS = "Deleted Link: %1$s from %2$s";

--- a/src/main/java/seedu/address/logic/commands/tagcommands/TagDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tagcommands/TagDeleteCommand.java
@@ -27,7 +27,7 @@ public class TagDeleteCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the tag identified by the index number used in the displayed tag list.\n"
-            + "Parameters: INDEX (must be a positive integer from 0 to " + Integer.MAX_VALUE + ")\n"
+            + "Parameters: INDEX (must be a positive integer from 1 to " + Integer.MAX_VALUE + ")\n"
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_DELETE_TAG_SUCCESS = "Deleted Tag: %1$s";

--- a/src/main/java/seedu/address/logic/commands/tagcommands/TagDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tagcommands/TagDeleteCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands.tagcommands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_TAGS;
 
 import java.util.HashSet;
 import java.util.List;
@@ -64,6 +65,7 @@ public class TagDeleteCommand extends Command {
         }
 
         model.deleteTag(tagToDelete);
+        model.updateFilteredTagList(PREDICATE_SHOW_ALL_TAGS);
         return new CommandResult(String.format(MESSAGE_DELETE_TAG_SUCCESS, tagToDelete));
     }
 

--- a/src/main/java/seedu/address/logic/commands/tagcommands/TagEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tagcommands/TagEditCommand.java
@@ -26,7 +26,7 @@ public class TagEditCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the name of the tag identified "
             + "by the index number used in the displayed tag list. "
             + "Existing values will be overwritten by the input values.\n"
-            + "Parameters: INDEX (must be a positive integer from 0 to " + Integer.MAX_VALUE + ") "
+            + "Parameters: INDEX (must be a positive integer from 1 to " + Integer.MAX_VALUE + ") "
             + PREFIX_TAG + "TAG NAME\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_TAG + "CS2101";

--- a/src/main/java/seedu/address/logic/commands/tagcommands/TagEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tagcommands/TagEditCommand.java
@@ -31,7 +31,7 @@ public class TagEditCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_TAG + "CS2101";
 
-    public static final String MESSAGE_EDIT_TAG_SUCCESS = "Edited Tag: %1$s";
+    public static final String MESSAGE_EDIT_TAG_SUCCESS = "Edited Tag: %1$s to %2$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_TAG = "This tag already exists in Projact.";
 

--- a/src/main/java/seedu/address/logic/commands/tagcommands/TagSortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tagcommands/TagSortCommand.java
@@ -13,8 +13,8 @@ import seedu.address.model.tag.TagNameComparator;
 public class TagSortCommand extends Command {
     public static final String COMMAND_WORD = "tagsort";
 
-    public static final String MESSAGE_SUCCESS = "These are the tags in your tag list sorted in ascending number "
-                                            + "then alphabetical order.";
+    public static final String MESSAGE_SUCCESS = "These are the tags in your tag list sorted in "
+                                            + "alphanumerical order.";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/address/logic/commands/tagcommands/TaskAddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tagcommands/TaskAddCommand.java
@@ -27,7 +27,7 @@ public class TaskAddCommand extends Command {
     public static final String COMMAND_WORD = "taskadd";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a task to a tag. "
-            + "Parameters: INDEX (must be a positive integer from 0 to " + Integer.MAX_VALUE + ") "
+            + "Parameters: INDEX (must be a positive integer from 1 to " + Integer.MAX_VALUE + ") "
             + PREFIX_TASK + "TASK DESCRIPTION "
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_TASK + "Peer review ";

--- a/src/main/java/seedu/address/logic/commands/tagcommands/TaskDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tagcommands/TaskDeleteCommand.java
@@ -24,7 +24,7 @@ public class TaskDeleteCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Delete the task identified by the alphabetical "
             + "index number used in the task list \n of the tag, which is identified by the numerical index used in "
             + "the displayed tag list. \n"
-            + "Parameters: \n1. INDEX (must be a positive integer from 0 to " + Integer.MAX_VALUE + ") \n"
+            + "Parameters: \n1. INDEX (must be a positive integer from 1 to " + Integer.MAX_VALUE + ") \n"
             + "2. ALPHABETICAL INDEX (must be an alphabet in lower case from 'a' to 'z') \n"
             + "Example: " + COMMAND_WORD + " 1 a";
 

--- a/src/main/java/seedu/address/logic/commands/tagcommands/TaskDoneCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tagcommands/TaskDoneCommand.java
@@ -23,7 +23,7 @@ public class TaskDoneCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Mark the task identified by the alphabetical "
             + "index number used in the task list \n of the tag, which is identified by the numerical index used in "
             + "the displayed tag list. \n"
-            + "Parameters: \n 1. INDEX (must be a positive integer from 0 to " + Integer.MAX_VALUE + ")\n"
+            + "Parameters: \n 1. INDEX (must be a positive integer from 1 to " + Integer.MAX_VALUE + ")\n"
             + "2. ALPHABETICAL INDEX (must be an alphabet in lower case from 'a' to 'z')\n"
             + "Example: " + COMMAND_WORD + " 1 a";
 

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -10,7 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Email {
 
     private static final String SPECIAL_CHARACTERS = "!#$%&'*+/=?`{|}~^.-";
-    public static final String MESSAGE_CONSTRAINTS = "Email should be of the format local-part@domain.extension "
+    public static final String MESSAGE_CONSTRAINTS = "Email addresses should be of the format local-part@domain.extension "
             + "and adhere to the following constraints:\n"
             + "1. The local-part should only contain alphanumeric characters and these special characters, excluding "
             + "the parentheses, (" + SPECIAL_CHARACTERS + ") .\n"

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -10,7 +10,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Email {
 
     private static final String SPECIAL_CHARACTERS = "!#$%&'*+/=?`{|}~^.-";
-    public static final String MESSAGE_CONSTRAINTS = "Email addresses should be of the format local-part@domain.extension "
+    public static final String MESSAGE_CONSTRAINTS = "Email addresses should be of the format "
+            + "local-part@domain.extension "
             + "and adhere to the following constraints:\n"
             + "1. The local-part should only contain alphanumeric characters and these special characters, excluding "
             + "the parentheses, (" + SPECIAL_CHARACTERS + ") .\n"

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -10,7 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Email {
 
     private static final String SPECIAL_CHARACTERS = "!#$%&'*+/=?`{|}~^.-";
-    public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain.extension "
+    public static final String MESSAGE_CONSTRAINTS = "Email should be of the format local-part@domain.extension "
             + "and adhere to the following constraints:\n"
             + "1. The local-part should only contain alphanumeric characters and these special characters, excluding "
             + "the parentheses, (" + SPECIAL_CHARACTERS + ") .\n"

--- a/src/main/java/seedu/address/model/person/TelegramAddress.java
+++ b/src/main/java/seedu/address/model/person/TelegramAddress.java
@@ -10,7 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class TelegramAddress {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Telegram addresses have the following constraints: "
+            "Telegram addresses have the following constraints: \n"
                 + " 1. They can only contain alphanumeric characters and underscores with no spaces in between.\n"
                 + " 2. They should be 5 - 32 characters long.\n"
                 + " 3. They must start with an alphabet letter and end with an alphanumeric character.";

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -114,7 +114,7 @@ public class Tag {
             getMeetingLink().ifPresent(link -> builder.append(link));
         }
 
-        if(!getTagTasks().isEmpty()) {
+        if (!getTagTasks().isEmpty()) {
             builder.append(" Tasks: ");
             getTagTasks().forEach(builder::append);
         }

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -108,11 +108,16 @@ public class Tag {
     @Override
     public String toString() {
         final StringBuilder builder = new StringBuilder();
-        builder.append(getTagName())
-                .append(" Link: ");
-        getMeetingLink().ifPresent(link -> builder.append(link));
-        builder.append(" Tasks: ");
-        getTagTasks().forEach(builder::append);
+        builder.append(getTagName());
+        if (!getMeetingLink().isEmpty()) {
+            builder.append(" Link: ");
+            getMeetingLink().ifPresent(link -> builder.append(link));
+        }
+
+        if(!getTagTasks().isEmpty()) {
+            builder.append(" Tasks: ");
+            getTagTasks().forEach(builder::append);
+        }
 
         return builder.toString();
     }

--- a/src/test/java/seedu/address/logic/commands/contactcommands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contactcommands/DeleteCommandTest.java
@@ -58,7 +58,6 @@ public class DeleteCommandTest {
 
         Model expectedModel = new ModelManager(model.getProjact(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);
-        showNoPerson(expectedModel);
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
     }
@@ -98,12 +97,4 @@ public class DeleteCommandTest {
         assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
     }
 
-    /**
-     * Updates {@code model}'s filtered list to show no one.
-     */
-    private void showNoPerson(Model model) {
-        model.updateFilteredPersonList(p -> false);
-
-        assertTrue(model.getFilteredPersonList().isEmpty());
-    }
 }

--- a/src/test/java/seedu/address/logic/commands/tagcommands/TagDeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/tagcommands/TagDeleteCommandTest.java
@@ -58,7 +58,6 @@ public class TagDeleteCommandTest {
 
         Model expectedModel = new ModelManager(model.getProjact(), new UserPrefs());
         expectedModel.deleteTag(tagToDelete);
-        showNoTag(expectedModel);
 
         assertCommandSuccess(tagDeleteCommand, model, expectedMessage, expectedModel);
     }
@@ -98,12 +97,4 @@ public class TagDeleteCommandTest {
         assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
     }
 
-    /**
-     * Updates {@code model}'s filtered list to show no one.
-     */
-    private void showNoTag(Model model) {
-        model.updateFilteredTagList(p -> false);
-
-        assertTrue(model.getFilteredTagList().isEmpty());
-    }
 }

--- a/src/test/java/seedu/address/logic/commands/tagcommands/TagEditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/tagcommands/TagEditCommandTest.java
@@ -50,7 +50,7 @@ public class TagEditCommandTest {
         TagEditCommand tagEditCommand = new TagEditCommand(INDEX_FIRST_TAG, new EditTagDescriptor());
         Tag editedTag = model.getFilteredTagList().get(INDEX_FIRST_TAG.getZeroBased());
 
-        String expectedMessage = String.format(TagEditCommand.MESSAGE_EDIT_TAG_SUCCESS, editedTag);
+        String expectedMessage = String.format(TagEditCommand.MESSAGE_EDIT_TAG_SUCCESS, editedTag, editedTag);
 
         Model expectedModel = new ModelManager(new Projact(model.getProjact()), new UserPrefs());
 


### PR DESCRIPTION
Problems with DeleteCommand:
(Initial)
1. Edit after find --> go to the full person list
2. Add after find --> go to the full person list
3. delete after find --> remains at the find window (because delete does not updateFilteredPersonList() at the end)

so to make it consistent, updateFilteredPersonList was added to deleteCommand. Similarly to tagDeleteCommand

Even though it will be better actually if edit, add remain at the find window (because we can do more edits if required). Should we write this under known issues in DG?

Another problem fixed: Tagedit success message 